### PR TITLE
docs: fix README to install from git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ filexp
 
 Install Go and run:
 
-`go install github.com/aschmahmann/filexp`
+```
+git clone https://github.com/aschmahmann/filexp
+cd filexp
+go install
+```
 
 ## Running
 


### PR DESCRIPTION
fixes #1

Apparently there's a Go issue no one is interested in fixing https://github.com/golang/go/issues/44840. It's probably because they feel that downstreams should deal with this directly (e.g. not requiring `replace https://github.com/filecoin-project/ffi-stub` in many projects that imports lotus https://github.com/filecoin-project/lotus/discussions/9280).