### PR TITLE
Remove waiting in setting up Filecoin-based retrieval

### DIFF
--- a/filnet.go
+++ b/filnet.go
@@ -58,23 +58,7 @@ func setupFilContentFetching(h host.Host, ctx context.Context) (*bsclient.Client
 		return nil, err
 	}
 
-	// wait until we have a certain number of peers before returning
-	// TODO: is this a useful optimization based on how the boxo/bitswap implementation currently works?
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if np := len(h.Network().Peers()); np > len(boostrappers)*2 {
-				return bs, nil
-			} else {
-				fmt.Printf("number of peers: %d\n", np)
-			}
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
+	return bs, nil
 }
 
 func setupFilBootstrapping(ctx context.Context, h host.Host) error {

--- a/filnet.go
+++ b/filnet.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -84,8 +83,6 @@ func setupPubSub(ctx context.Context, h host.Host) error {
 		return err
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(len(boostrappers))
 	for _, bstr := range boostrappers {
 		ai, err := peer.AddrInfoFromString(bstr)
 		if err != nil {
@@ -93,10 +90,8 @@ func setupPubSub(ctx context.Context, h host.Host) error {
 		}
 		go func() {
 			_ = h.Connect(ctx, *ai)
-			wg.Done()
 		}()
 	}
-	wg.Wait()
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
These don't seem necessary and make simple commands take much longer than they should need to. This cuts down the time of a simple command like `fil-to-eth-address` from 15+ seconds to start up to being finished in under a second.