### PR TITLE
Extract all iterators into standalone functions

### DIFF
--- a/addrcmd.go
+++ b/addrcmd.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	lchstate "github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/urfave/cli/v2"
@@ -37,11 +36,7 @@ func filToEthAddr(cctx *cli.Context) error {
 	}
 	defer bg.LogStats()
 
-	stateTree, err := lchstate.LoadStateTree(ipldcbor.NewCborStore(bg), ts.ParentState())
-	if err != nil {
-		return err
-	}
-	idAddr, err := stateTree.LookupIDAddress(addr)
+	idAddr, err := lookupID(cctx.Context, ipldcbor.NewCborStore(bg), ts, addr)
 	if err != nil {
 		return err
 	}
@@ -87,12 +82,7 @@ func filAddrs(cctx *cli.Context) error {
 	}
 	defer bg.LogStats()
 
-	stateTree, err := lchstate.LoadStateTree(ipldcbor.NewCborStore(bg), ts.ParentState())
-	if err != nil {
-		return err
-	}
-
-	idAddr, err := stateTree.LookupIDAddress(addr)
+	idAddr, err := lookupID(cctx.Context, ipldcbor.NewCborStore(bg), ts, addr)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.26.1
 	github.com/libp2p/go-libp2p-pubsub v0.12.0
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.4
+	github.com/minio/sha256-simd v1.0.1
 	github.com/ribasushi/go-toolbox-interplanetary v0.0.0-20240514200055-57ad72c3510f
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/whyrusleeping/cbor-gen v0.1.2
@@ -146,7 +147,6 @@ require (
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
-	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect


### PR DESCRIPTION
- `lookupID` is consolidated across 3 callsites

- both `parseActors` and `enumActors` are folded into their respective sole callers

- these are then rewritten in terms of 
```
func iterateActors(
  ctx context.Context,
  cbs *ipldcbor.BasicIpldStore,
  ts *lchtypes.TipSet,
  cb func(actorID filaddr.Address, actor lchtypes.Actor) error,
) error {...}
```

- which itself is then rewritten in terms of
```
func parallelIterateMap(
  ctx context.Context,
  cbs *ipldcbor.BasicIpldStore,
  root cid.Cid,
  cb func(k, vCbor []byte) error,
) error {...}
```

