### PR TITLE
Add dump-statemarketdeals command

### DIFF
--- a/addrcmd.go
+++ b/addrcmd.go
@@ -31,7 +31,7 @@ func filToEthAddr(cctx *cli.Context) error {
 		return fmt.Errorf("error unsupported address type %v", p)
 	}
 
-	bg, ts, err := getAnchorPoint(cctx)
+	bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func filAddrs(cctx *cli.Context) error {
 		}
 	}
 
-	bg, ts, err := getAnchorPoint(cctx)
+	bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 	if err != nil {
 		return err
 	}

--- a/fvmcmds_build.go
+++ b/fvmcmds_build.go
@@ -47,7 +47,7 @@ func cmdFevmExec(cctx *cli.Context) error {
 		return xerrors.Errorf("could not decode hex bytes: %w", err)
 	}
 
-	bg, ts, err := getAnchorPoint(cctx)
+	bg, ts, err := getAnchorPoint(cctx, true) // force FullCBG
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func cmdFevmDaemon(cctx *cli.Context) error {
 		return err
 	}
 
-	bg, ts, err := getAnchorPoint(cctx)
+	bg, ts, err := getAnchorPoint(cctx, true) // force FullCBG
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (e *ethRpcResolver) Call(ctx context.Context, eaddr ethtypes.EthAddress, me
 	return ret, nil
 }
 
-func fevmExec(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, eaddr *ethtypes.EthAddress, edata ethtypes.EthBytes, outputCAR string) error {
+func fevmExec(ctx context.Context, bg ipld.CountingBlockGetter, ts *lchtypes.TipSet, eaddr *ethtypes.EthAddress, edata ethtypes.EthBytes, outputCAR string) error {
 	filMsg, err := (&ethtypes.EthCall{To: eaddr, Data: edata}).ToFilecoinMessage()
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.30.2
 	github.com/libp2p/go-libp2p-pubsub v0.13.1
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.5
+	github.com/mattn/go-isatty v0.0.20
 	github.com/minio/sha256-simd v1.0.1
 	github.com/urfave/cli/v2 v2.27.5
 	github.com/whyrusleeping/cbor-gen v0.3.1
@@ -144,7 +145,6 @@ require (
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 	github.com/miekg/dns v1.1.63 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect

--- a/internal/bitswap/core.go
+++ b/internal/bitswap/core.go
@@ -23,7 +23,7 @@ import (
 
 var log = filexp.Logger
 
-func InitBitswapGetter(ctx context.Context) (*ipld.CountingBlockGetter, error) {
+func InitBitswapGetter(ctx context.Context, useFullCBG bool) (ipld.CountingBlockGetter, error) {
 	start := time.Now()
 	defer func() {
 		log.Infof("duration to setup bitswap fetching: %v", time.Since(start))
@@ -52,11 +52,17 @@ func InitBitswapGetter(ctx context.Context) (*ipld.CountingBlockGetter, error) {
 		bscFil.NewSession(ctx),
 		bscIpfs.NewSession(ctx),
 	}
-	bg := &ipld.CountingBlockGetter{
-		IpldBlockstore: &bservWrapper{
-			IpldBlockstore: blockstore.NewBlockstore(lds),
-			bserv:          cf,
-		},
+
+	var bg ipld.CountingBlockGetter
+	bsw := &bservWrapper{
+		IpldBlockstore: blockstore.NewBlockstore(lds),
+		bserv:          cf,
+	}
+
+	if useFullCBG {
+		bg = &ipld.FullCBG{IpldBlockstore: bsw}
+	} else {
+		bg = &ipld.LiteCBG{IpldBlockstore: bsw}
 	}
 
 	go func() {
@@ -98,7 +104,8 @@ func InitBitswapGetter(ctx context.Context) (*ipld.CountingBlockGetter, error) {
 					"peersIpfsBS", nPeersWithIpfsBitswap,
 					"wantsIpfsBS", nwantsIpfs,
 					"blksFromIpfsBS", nIpfsBlks,
-					"blksTotal", bg.UniqueBlockCount(),
+					"blksTotal", bg.TotalBlockCount(),
+					"blksUnique", bg.UniqueBlockCount(),
 				)
 			}
 		}

--- a/internal/ipld/blockgetter.go
+++ b/internal/ipld/blockgetter.go
@@ -2,6 +2,7 @@ package ipld
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -13,17 +14,71 @@ import (
 
 var log = filexp.Logger
 
-type CountingBlockGetter struct {
+type CountingBlockGetter interface {
+	ipldcbor.IpldBlockstore
+	LogStats()
+	TotalBlockCount() int64
+	UniqueBlockCount() string
+	OrderedCids() []cid.Cid
+}
+
+type LiteCBG struct {
+	ipldcbor.IpldBlockstore
+	mx       sync.Mutex
+	firstGet *time.Time
+	getCount int64
+}
+
+func (bg *LiteCBG) Get(ctx context.Context, c cid.Cid) (blkfmt.Block, error) {
+	blk, err := bg.IpldBlockstore.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	bg.mx.Lock()
+	{
+		if bg.firstGet == nil {
+			t := time.Now()
+			bg.firstGet = &t
+		}
+		bg.getCount++
+	}
+	bg.mx.Unlock()
+
+	return blk, nil
+}
+
+func (bg *LiteCBG) LogStats() {
+	bg.mx.Lock()
+	defer bg.mx.Unlock()
+
+	tsfg := "n/a"
+	if bg.firstGet != nil {
+		tsfg = time.Since(*bg.firstGet).Truncate(time.Millisecond).String()
+	}
+	log.Infow("blockgetterStats", "blocksTotal", bg.getCount, "timeSinceFirstGet", tsfg)
+}
+
+func (bg *LiteCBG) TotalBlockCount() int64 {
+	bg.mx.Lock()
+	defer bg.mx.Unlock()
+
+	return bg.getCount
+}
+
+func (bg *LiteCBG) UniqueBlockCount() string { return "n/a" }
+func (bg *LiteCBG) OrderedCids() []cid.Cid   { return nil }
+
+type FullCBG struct {
 	ipldcbor.IpldBlockstore
 	mx          sync.Mutex
 	firstGet    *time.Time
+	getCount    int64
 	m           map[cid.Cid]int
 	orderedCids []cid.Cid
 }
 
-var _ ipldcbor.IpldBlockstore = &CountingBlockGetter{}
-
-func (bg *CountingBlockGetter) Get(ctx context.Context, c cid.Cid) (blkfmt.Block, error) {
+func (bg *FullCBG) Get(ctx context.Context, c cid.Cid) (blkfmt.Block, error) {
 	blk, err := bg.IpldBlockstore.Get(ctx, c)
 	if err != nil {
 		return nil, err
@@ -40,35 +95,45 @@ func (bg *CountingBlockGetter) Get(ctx context.Context, c cid.Cid) (blkfmt.Block
 			bg.m[c] = len(blk.RawData())
 			bg.orderedCids = append(bg.orderedCids, c)
 		}
+		bg.getCount++
 	}
 	bg.mx.Unlock()
 
 	return blk, nil
 }
 
-func (bg *CountingBlockGetter) LogStats() {
+func (bg *FullCBG) LogStats() {
 	bg.mx.Lock()
-	totalSizeBytes := 0
+	defer bg.mx.Unlock()
+
+	uniqueSizeBytes := 0
 	for _, v := range bg.m {
-		totalSizeBytes += v
+		uniqueSizeBytes += v
 	}
 	tsfg := "n/a"
 	if bg.firstGet != nil {
 		tsfg = time.Since(*bg.firstGet).Truncate(time.Millisecond).String()
 	}
-	log.Infow("blockgetterStats", "blocksCount", len(bg.m), "blocksBytes", totalSizeBytes, "timeSinceFirstGet", tsfg)
-	bg.mx.Unlock()
+	log.Infow("blockgetterStats", "blocksTotal", bg.getCount, "blocksUnique", len(bg.m), "uniqueBytes", uniqueSizeBytes, "timeSinceFirstGet", tsfg)
 }
 
-func (bg *CountingBlockGetter) UniqueBlockCount() (cnt int) {
-	bg.mx.Lock()
-	cnt = len(bg.m)
-	bg.mx.Unlock()
-	return
-}
-
-func (bg *CountingBlockGetter) OrderedCids() []cid.Cid {
+func (bg *FullCBG) TotalBlockCount() int64 {
 	bg.mx.Lock()
 	defer bg.mx.Unlock()
+
+	return bg.getCount
+}
+
+func (bg *FullCBG) UniqueBlockCount() string {
+	bg.mx.Lock()
+	defer bg.mx.Unlock()
+
+	return fmt.Sprintf("%d", len(bg.m))
+}
+
+func (bg *FullCBG) OrderedCids() []cid.Cid {
+	bg.mx.Lock()
+	defer bg.mx.Unlock()
+
 	return bg.orderedCids
 }

--- a/internal/ipld/car.go
+++ b/internal/ipld/car.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func GetStateFromCar(ctx context.Context, srcSnapshot string) (*CountingBlockGetter, *lchtypes.TipSetKey, error) {
+func GetStateFromCar(ctx context.Context, srcSnapshot string, useFullCBG bool) (CountingBlockGetter, *lchtypes.TipSetKey, error) {
 	start := time.Now()
 
 	carbs, err := blockstoreFromSnapshot(srcSnapshot)
@@ -35,7 +35,10 @@ func GetStateFromCar(ctx context.Context, srcSnapshot string) (*CountingBlockGet
 		carbs.Close()
 	}()
 
-	return &CountingBlockGetter{IpldBlockstore: carbs}, &tsk, nil
+	if useFullCBG {
+		return &FullCBG{IpldBlockstore: carbs}, &tsk, nil
+	}
+	return &LiteCBG{IpldBlockstore: carbs}, &tsk, nil
 }
 
 func blockstoreFromSnapshot(snapshotFilename string) (*carbs.ReadOnly, error) {

--- a/internal/state/explore.go
+++ b/internal/state/explore.go
@@ -18,7 +18,7 @@ import (
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 )
 
-func GetCoins(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, addr filaddr.Address) error {
+func GetCoins(ctx context.Context, bg ipld.CountingBlockGetter, ts *lchtypes.TipSet, addr filaddr.Address) error {
 	cbs := ipldcbor.NewCborStore(bg)
 	var mx sync.Mutex
 	foundAttoFil := filabi.NewTokenAmount(0)
@@ -81,7 +81,7 @@ func GetCoins(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.Ti
 	return nil
 }
 
-func GetActors(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, countOnly bool) error {
+func GetActors(ctx context.Context, bg ipld.CountingBlockGetter, ts *lchtypes.TipSet, countOnly bool) error {
 	var numActors uint64
 
 	if err := IterateActors(ctx, ipldcbor.NewCborStore(bg), ts, func(actorID filaddr.Address, act lchtypes.Actor) error {
@@ -101,7 +101,7 @@ func GetActors(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.T
 	return nil
 }
 
-func GetBalance(_ context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, addr filaddr.Address) error {
+func GetBalance(_ context.Context, bg ipld.CountingBlockGetter, ts *lchtypes.TipSet, addr filaddr.Address) error {
 	act, err := GetActorGeneric(ipldcbor.NewCborStore(bg), ts, addr)
 	if err != nil {
 		return err

--- a/internal/state/f05.go
+++ b/internal/state/f05.go
@@ -1,0 +1,199 @@
+package state
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/aschmahmann/filexp/internal/ipld"
+	filabi "github.com/filecoin-project/go-state-types/abi"
+	filbuiltin "github.com/filecoin-project/go-state-types/builtin"
+	lchadt "github.com/filecoin-project/lotus/chain/actors/adt"
+	lchmarket "github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	lchtypes "github.com/filecoin-project/lotus/chain/types"
+	ipldcbor "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/sync/errgroup"
+)
+
+type MarketDealState struct {
+	SectorNumber     filabi.SectorNumber
+	SectorStartEpoch filabi.ChainEpoch
+	LastUpdatedEpoch filabi.ChainEpoch
+	SlashEpoch       filabi.ChainEpoch
+}
+type JsonEntry struct {
+	DealID   *filabi.DealID `json:",omitempty"`
+	Proposal lchmarket.DealProposal
+	State    MarketDealState
+}
+
+func DumpStateF05(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, outFh io.Writer, asSingleDocument bool) error {
+	// POSIX pipe writes are not atomic after certain size, we need a synchronizer not to tear the json
+	// run the worker in an outer errgroup to allow for all producers to shut down first
+	writeSink := make(chan []byte, 8<<10)
+	egOuter, ctx := errgroup.WithContext(ctx)
+	egOuter.Go(func() error { return writeWorker(ctx, writeSink, outFh, asSingleDocument) })
+
+	egInner, ctx := errgroup.WithContext(ctx)
+	wrkCnt := runtime.NumCPU()
+	if wrkCnt < 3 {
+		wrkCnt = 3 // one iterator, and at least two encoders
+	} else if wrkCnt > 12 {
+		wrkCnt = 12 // do not overwhelm the block provider
+	}
+	egInner.SetLimit(wrkCnt)
+
+	//
+	// begin actual chain-reading logic
+	//
+	cbs := ipldcbor.NewCborStore(bg)
+
+	f05act, err := GetActorGeneric(cbs, ts, filbuiltin.StorageMarketActorAddr)
+	if err != nil {
+		return err
+	}
+	f05state, err := lchmarket.Load(lchadt.WrapStore(ctx, cbs), f05act)
+	if err != nil {
+		return err
+	}
+
+	proposals, err := f05state.Proposals()
+	if err != nil {
+		return err
+	}
+
+	states, err := f05state.States()
+	if err != nil {
+		return err
+	}
+
+	egInner.Go(func() error {
+		var cnt atomic.Int64
+
+		// Currently this takes ~2 minutes for a `return nil` noop via a car file 🪦
+		// It should take ~10 seconds instead (based on napking math over tree size, 2.7M blocks)
+		//
+		// The reason for the discrepancy is lack of a counterpart parallelIterateArray modeled on
+		// https://github.com/aschmahmann/filexp/blob/6f5f5d16f7e/internal/ipld/adl.go#L22-L36
+		// to then be able to burn through these 2 arrays in parallel and "zip" them up
+		// https://github.com/filecoin-project/builtin-actors/blob/v15.0.0/actors/market/src/state.rs#L40-L48
+		//
+		// Blockers are this PR and its deps: https://github.com/filecoin-project/go-amt-ipld/pull/84
+		//
+		return proposals.ForEach(func(did filabi.DealID, dp lchmarket.DealProposal) error {
+
+			// keep count, also to deal with trailing comma in case of asSingleDocument
+			isFirst := (cnt.Add(1) == 1)
+
+			egInner.Go(func() error {
+
+				// https://github.com/filecoin-project/lotus/blob/v1.30.0/chain/actors/builtin/market/market.go#L306-L320
+				mds := MarketDealState{
+					SectorNumber:     0,
+					SectorStartEpoch: -1,
+					LastUpdatedEpoch: -1,
+					SlashEpoch:       -1,
+				}
+				s, found, err := states.Get(did)
+				if err != nil {
+					return err
+				}
+				if found {
+					mds.SectorNumber = s.SectorNumber()
+					mds.SectorStartEpoch = s.SectorStartEpoch()
+					mds.LastUpdatedEpoch = s.LastUpdatedEpoch()
+					mds.SlashEpoch = s.SlashEpoch()
+				}
+
+				// if we do end up with proper concurrency (see comment above), dealing with pooled allocs will be worthwhile
+				// right now it's definitively a wash
+				toEnc := JsonEntry{
+					Proposal: dp,
+					State:    mds,
+				}
+				if !asSingleDocument {
+					toEnc.DealID = &did
+				}
+
+				enc, err := json.Marshal(toEnc)
+				if err != nil {
+					return err
+				}
+
+				encFin := make([]byte, 0, len(enc)+15)
+
+				if asSingleDocument {
+					if !isFirst {
+						encFin = append(encFin, ","...)
+					}
+					encFin = append(encFin, fmt.Sprintf(`"%d":`, did)...)
+					encFin = append(encFin, enc...)
+				} else {
+					encFin = append(encFin, enc...)
+					encFin = append(encFin, "\n"...)
+				}
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case writeSink <- encFin:
+				}
+
+				return nil
+			})
+			return nil
+		})
+	})
+
+	innerErr := egInner.Wait()
+	close(writeSink)
+	outerErr := egOuter.Wait()
+
+	if innerErr != nil {
+		return innerErr
+	} else if outerErr != nil {
+		return outerErr
+	}
+
+	return nil
+}
+
+func writeWorker(ctx context.Context, in <-chan []byte, out io.Writer, asSingleDocument bool) (defErr error) {
+
+	buf := bufio.NewWriterSize(out, 1<<20)
+	defer func() {
+		if defErr == nil {
+			defErr = buf.Flush()
+		}
+	}()
+
+	if asSingleDocument {
+		if _, err := buf.Write([]byte(`{"id":1,"jsonrpc":"2.0","result":{`)); err != nil {
+			return err
+		}
+		defer func() {
+			_, err := buf.Write([]byte("}}\n"))
+			if defErr == nil {
+				defErr = err
+			}
+		}()
+	}
+
+	for {
+		select {
+		case b, isOpen := <-in:
+			if !isOpen {
+				return nil
+			}
+			if _, err := buf.Write(b); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/internal/state/f05.go
+++ b/internal/state/f05.go
@@ -25,7 +25,7 @@ type deal struct {
 	proposal *lchmarket.DealProposal
 }
 
-func DumpStateF05(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, outFh io.Writer, asSingleDocument bool) (defErr error) {
+func DumpStateF05(ctx context.Context, bg ipld.CountingBlockGetter, ts *lchtypes.TipSet, outFh io.Writer, asSingleDocument bool) (defErr error) {
 
 	//
 	// Setup various chain access

--- a/internal/state/f05.go
+++ b/internal/state/f05.go
@@ -2,12 +2,13 @@ package state
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"runtime"
-	"sync/atomic"
+	"sync"
 
 	"github.com/aschmahmann/filexp/internal/ipld"
 	filabi "github.com/filecoin-project/go-state-types/abi"
@@ -19,36 +20,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type MarketDealState struct {
-	SectorNumber     filabi.SectorNumber
-	SectorStartEpoch filabi.ChainEpoch
-	LastUpdatedEpoch filabi.ChainEpoch
-	SlashEpoch       filabi.ChainEpoch
-}
-type JsonEntry struct {
-	DealID   *filabi.DealID `json:",omitempty"`
-	Proposal lchmarket.DealProposal
-	State    MarketDealState
+type deal struct {
+	dealID   filabi.DealID
+	proposal *lchmarket.DealProposal
 }
 
-func DumpStateF05(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, outFh io.Writer, asSingleDocument bool) error {
-	// POSIX pipe writes are not atomic after certain size, we need a synchronizer not to tear the json
-	// run the worker in an outer errgroup to allow for all producers to shut down first
-	writeSink := make(chan []byte, 8<<10)
-	egOuter, ctx := errgroup.WithContext(ctx)
-	egOuter.Go(func() error { return writeWorker(ctx, writeSink, outFh, asSingleDocument) })
-
-	egInner, ctx := errgroup.WithContext(ctx)
-	wrkCnt := runtime.NumCPU()
-	if wrkCnt < 3 {
-		wrkCnt = 3 // one iterator, and at least two encoders
-	} else if wrkCnt > 12 {
-		wrkCnt = 12 // do not overwhelm the block provider
-	}
-	egInner.SetLimit(wrkCnt)
+func DumpStateF05(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtypes.TipSet, outFh io.Writer, asSingleDocument bool) (defErr error) {
 
 	//
-	// begin actual chain-reading logic
+	// Setup various chain access
 	//
 	cbs := ipldcbor.NewCborStore(bg)
 
@@ -61,139 +41,167 @@ func DumpStateF05(ctx context.Context, bg *ipld.CountingBlockGetter, ts *lchtype
 		return err
 	}
 
-	proposals, err := f05state.Proposals()
+	proposalsReader, err := f05state.Proposals()
 	if err != nil {
 		return err
 	}
 
-	states, err := f05state.States()
+	statesReader, err := f05state.States()
 	if err != nil {
 		return err
 	}
 
-	egInner.Go(func() error {
-		var cnt atomic.Int64
-
-		// Currently this takes ~2 minutes for a `return nil` noop via a car file 🪦
-		// It should take ~10 seconds instead (based on napking math over tree size, 2.7M blocks)
-		//
-		// The reason for the discrepancy is lack of a counterpart parallelIterateArray modeled on
-		// https://github.com/aschmahmann/filexp/blob/6f5f5d16f7e/internal/ipld/adl.go#L22-L36
-		// to then be able to burn through these 2 arrays in parallel and "zip" them up
-		// https://github.com/filecoin-project/builtin-actors/blob/v15.0.0/actors/market/src/state.rs#L40-L48
-		//
-		// Blockers are this PR and its deps: https://github.com/filecoin-project/go-amt-ipld/pull/84
-		//
-		return proposals.ForEach(func(did filabi.DealID, dp lchmarket.DealProposal) error {
-
-			// keep count, also to deal with trailing comma in case of asSingleDocument
-			isFirst := (cnt.Add(1) == 1)
-
-			egInner.Go(func() error {
-
-				// https://github.com/filecoin-project/lotus/blob/v1.30.0/chain/actors/builtin/market/market.go#L306-L320
-				mds := MarketDealState{
-					SectorNumber:     0,
-					SectorStartEpoch: -1,
-					LastUpdatedEpoch: -1,
-					SlashEpoch:       -1,
-				}
-				s, found, err := states.Get(did)
-				if err != nil {
-					return err
-				}
-				if found {
-					mds.SectorNumber = s.SectorNumber()
-					mds.SectorStartEpoch = s.SectorStartEpoch()
-					mds.LastUpdatedEpoch = s.LastUpdatedEpoch()
-					mds.SlashEpoch = s.SlashEpoch()
-				}
-
-				// if we do end up with proper concurrency (see comment above), dealing with pooled allocs will be worthwhile
-				// right now it's definitively a wash
-				toEnc := JsonEntry{
-					Proposal: dp,
-					State:    mds,
-				}
-				if !asSingleDocument {
-					toEnc.DealID = &did
-				}
-
-				enc, err := json.Marshal(toEnc)
-				if err != nil {
-					return err
-				}
-
-				encFin := make([]byte, 0, len(enc)+15)
-
-				if asSingleDocument {
-					if !isFirst {
-						encFin = append(encFin, ","...)
-					}
-					encFin = append(encFin, fmt.Sprintf(`"%d":`, did)...)
-					encFin = append(encFin, enc...)
-				} else {
-					encFin = append(encFin, enc...)
-					encFin = append(encFin, "\n"...)
-				}
-
-				select {
-				case <-ctx.Done():
-					return nil
-				case writeSink <- encFin:
-				}
-
-				return nil
-			})
-			return nil
-		})
-	})
-
-	innerErr := egInner.Wait()
-	close(writeSink)
-	outerErr := egOuter.Wait()
-
-	if innerErr != nil {
-		return innerErr
-	} else if outerErr != nil {
-		return outerErr
-	}
-
-	return nil
-}
-
-func writeWorker(ctx context.Context, in <-chan []byte, out io.Writer, asSingleDocument bool) (defErr error) {
-
-	buf := bufio.NewWriterSize(out, 1<<20)
+	//
+	// Setup output
+	//
+	outBuf := bufio.NewWriterSize(outFh, 1<<20) // 1 MiB buffer, because why not
 	defer func() {
 		if defErr == nil {
-			defErr = buf.Flush()
+			defErr = outBuf.Flush()
 		}
 	}()
 
 	if asSingleDocument {
-		if _, err := buf.Write([]byte(`{`)); err != nil {
+		if _, err := outBuf.WriteString(`{`); err != nil {
 			return err
 		}
 		defer func() {
-			_, err := buf.Write([]byte("}\n"))
+			_, err := outBuf.WriteString("}\n")
 			if defErr == nil {
 				defErr = err
 			}
 		}()
 	}
 
-	for {
-		select {
-		case b, isOpen := <-in:
-			if !isOpen {
-				return nil
+	//
+	// Setup emitter workers
+	//
+	wrkCnt := runtime.NumCPU() - 1
+	if wrkCnt < 1 {
+		wrkCnt = 1
+	} else if wrkCnt > 12 {
+		wrkCnt = 12 // do not overwhelm the block provider
+	}
+
+	deals := make(chan deal, 16*wrkCnt)
+	notFirst := new(bool)
+
+	// Neither stdlib bufio, nor POSIX pipe writes are atomic
+	// need a synchronizer either way not to tear the JSON
+	mu := new(sync.Mutex)
+
+	// this ctx is not passed to workers: they are shut down on closed input channel alone
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for i := wrkCnt; i > 0; i-- {
+		eg.Go(func() error { return dealEmitter(asSingleDocument, deals, statesReader, outBuf, mu, notFirst) })
+	}
+
+	//
+	// Actual chain-reading logic
+	//
+	// Currently this takes ~2 minutes for a `return nil` noop via a car file 🪦
+	// It should take ~10 seconds instead (based on napking math over tree size, 2.7M blocks)
+	//
+	// The reason for the discrepancy is lack of a counterpart parallelIterateArray modeled on
+	// https://github.com/aschmahmann/filexp/blob/6f5f5d16f7e/internal/ipld/adl.go#L22-L36
+	// to then be able to burn through these 2 arrays in parallel and "zip" them up
+	// https://github.com/filecoin-project/builtin-actors/blob/v15.0.0/actors/market/src/state.rs#L40-L48
+	//
+	// Blockers are this PR and its deps: https://github.com/filecoin-project/go-amt-ipld/pull/84
+	//
+	eg.Go(func() error {
+		// if any of the consumers of chan deals errors out, context below is cancelled, so the channeld is closed, so the consumers shut down
+		defer close(deals)
+		return proposalsReader.ForEach(func(did filabi.DealID, dp lchmarket.DealProposal) error {
+			select {
+			case <-ctx.Done():
+			case deals <- deal{did, &dp}:
 			}
-			if _, err := buf.Write(b); err != nil {
-				return err
-			}
-		case <-ctx.Done():
 			return nil
+		})
+	})
+
+	return eg.Wait()
+}
+
+func dealEmitter(asSingleDoc bool, deals <-chan deal, stateReader lchmarket.DealStates, out *bufio.Writer, mu *sync.Mutex, notFirst *bool) error {
+
+	// inline definition only here for clarity
+	// reuse struct across invocations - it has sufficiently low amount of fields that resetting everything is safe/fast
+	var toEnc struct {
+		DealID   *filabi.DealID `json:",omitempty"`
+		Proposal *lchmarket.DealProposal
+		State    struct {
+			SectorNumber     filabi.SectorNumber
+			SectorStartEpoch filabi.ChainEpoch
+			LastUpdatedEpoch filabi.ChainEpoch
+			SlashEpoch       filabi.ChainEpoch
+		}
+	}
+
+	jBuf := bytes.NewBuffer(make([]byte, 0, 1024)) // just a starting point, the buffer will self-grow if needed
+	jEnc := json.NewEncoder(jBuf)
+
+	for {
+		d, isOpen := <-deals
+		if !isOpen {
+			return nil
+		}
+
+		jBuf.Reset()
+
+		if asSingleDoc {
+			jBuf.WriteString(fmt.Sprintf(`"%d":`, d.dealID))
+		} else {
+			toEnc.DealID = &d.dealID
+		}
+
+		toEnc.Proposal = d.proposal
+
+		s, found, err := stateReader.Get(d.dealID)
+		if err != nil {
+			return err
+		}
+		if found {
+			toEnc.State.SectorNumber = s.SectorNumber()
+			toEnc.State.SectorStartEpoch = s.SectorStartEpoch()
+			toEnc.State.LastUpdatedEpoch = s.LastUpdatedEpoch()
+			toEnc.State.SlashEpoch = s.SlashEpoch()
+		} else {
+			// https://github.com/filecoin-project/lotus/blob/v1.30.0/chain/actors/builtin/market/market.go#L306-L320
+			toEnc.State.SectorNumber = 0
+			toEnc.State.SectorStartEpoch = -1
+			toEnc.State.LastUpdatedEpoch = -1
+			toEnc.State.SlashEpoch = -1
+		}
+
+		if err := jEnc.Encode(toEnc); err != nil {
+			return err
+		}
+
+		toWrite := jBuf.Bytes()
+
+		mu.Lock()
+		if asSingleDoc {
+			// write out the "leading" comma
+			if *notFirst {
+				_, err = out.WriteRune(',')
+			} else {
+				*notFirst = true
+			}
+
+			// strip the newline inserted by Encode() above
+			toWrite = toWrite[:len(toWrite)-1]
+		}
+		_, err2 := out.Write(toWrite)
+		mu.Unlock()
+
+		if err != nil {
+			return err
+		}
+		if err2 != nil {
+			return err2
 		}
 	}
 }

--- a/internal/state/f05.go
+++ b/internal/state/f05.go
@@ -172,11 +172,11 @@ func writeWorker(ctx context.Context, in <-chan []byte, out io.Writer, asSingleD
 	}()
 
 	if asSingleDocument {
-		if _, err := buf.Write([]byte(`{"id":1,"jsonrpc":"2.0","result":{`)); err != nil {
+		if _, err := buf.Write([]byte(`{`)); err != nil {
 			return err
 		}
 		defer func() {
-			_, err := buf.Write([]byte("}}\n"))
+			_, err := buf.Write([]byte("}\n"))
 			if defErr == nil {
 				defErr = err
 			}

--- a/main.go
+++ b/main.go
@@ -57,6 +57,10 @@ var stateFlags = []cli.Flag{
 		Usage:              "Equivalent to --rpc-endpoint=https://api.chain.love",
 		DisableDefaultText: true,
 	},
+	&cli.BoolFlag{
+		Name:  "count-unique-cids",
+		Usage: "Keep track of all CIDs seen, can be memory intensive",
+	},
 }
 
 func main() {
@@ -100,7 +104,7 @@ func main() {
 						return err
 					}
 
-					bg, ts, err := getAnchorPoint(cctx)
+					bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 					if err != nil {
 						return err
 					}
@@ -133,7 +137,7 @@ func main() {
 					if err != nil {
 						return err
 					}
-					bg, ts, err := getAnchorPoint(cctx)
+					bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 					if err != nil {
 						return err
 					}
@@ -153,7 +157,7 @@ func main() {
 					},
 				}, stateFlags...),
 				Action: func(cctx *cli.Context) error {
-					bg, ts, err := getAnchorPoint(cctx)
+					bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 					if err != nil {
 						return err
 					}
@@ -177,7 +181,7 @@ func main() {
 						return xerrors.New("dumping to terminal is not supported - redirect the output to file or pipe")
 					}
 
-					bg, ts, err := getAnchorPoint(cctx)
+					bg, ts, err := getAnchorPoint(cctx, cctx.Bool("count-unique-cids"))
 					if err != nil {
 						return err
 					}

--- a/main.go
+++ b/main.go
@@ -53,8 +53,9 @@ var stateFlags = []cli.Flag{
 		),
 	},
 	&cli.BoolFlag{
-		Name:  "trust-chainlove",
-		Usage: "Equivalent to --rpc-endpoint=https://api.chain.love",
+		Name:               "trust-chainlove",
+		Usage:              "Equivalent to --rpc-endpoint=https://api.chain.love",
+		DisableDefaultText: true,
 	},
 }
 
@@ -146,9 +147,9 @@ func main() {
 				Description: "List all actors",
 				Flags: append([]cli.Flag{
 					&cli.BoolFlag{
-						Name:        "count-only",
-						Value:       false,
-						DefaultText: "will not emit the actor IDs, and just count them",
+						Name:               "count-only",
+						Usage:              "will not emit the actor IDs, and just count them",
+						DisableDefaultText: true,
 					},
 				}, stateFlags...),
 				Action: func(cctx *cli.Context) error {
@@ -166,9 +167,9 @@ func main() {
 				Description: "Write legacy f05 state to STDOUT, semanitcally identical to FilRPC.StateMarketDeals()",
 				Flags: append([]cli.Flag{
 					&cli.BoolFlag{
-						Name:        "single-document",
-						Value:       false,
-						DefaultText: "emit an inefficient single JSON object identical to result of StateMarketDeals",
+						Name:               "single-document",
+						Usage:              "emit an inefficient single JSON object identical to FilRPC.StateMarketDeals.{Result}",
+						DisableDefaultText: true,
 					},
 				}, stateFlags...),
 				Action: func(cctx *cli.Context) error {

--- a/util.go
+++ b/util.go
@@ -27,7 +27,7 @@ func stringSliceMap(ss []string, f func(string) string) []string {
 	return ssout
 }
 
-func getAnchorPoint(cctx *cli.Context) (*ipld.CountingBlockGetter, *lchtypes.TipSet, error) {
+func getAnchorPoint(cctx *cli.Context, useFullCBG bool) (ipld.CountingBlockGetter, *lchtypes.TipSet, error) {
 	sourceSelect := []string{"car", "rpc-endpoint", "rpc-fullnode"}
 
 	var countHeadSources int
@@ -62,7 +62,7 @@ func getAnchorPoint(cctx *cli.Context) (*ipld.CountingBlockGetter, *lchtypes.Tip
 
 	ctx := cctx.Context
 	var err error
-	var bg *ipld.CountingBlockGetter
+	var bg ipld.CountingBlockGetter
 	var tsk *lchtypes.TipSetKey
 	var ts *lchtypes.TipSet
 
@@ -89,7 +89,7 @@ func getAnchorPoint(cctx *cli.Context) (*ipld.CountingBlockGetter, *lchtypes.Tip
 
 	if cctx.IsSet("car") {
 		var carTsk *lchtypes.TipSetKey
-		bg, carTsk, err = ipld.GetStateFromCar(ctx, cctx.String("car"))
+		bg, carTsk, err = ipld.GetStateFromCar(ctx, cctx.String("car"), useFullCBG)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -117,13 +117,17 @@ func getAnchorPoint(cctx *cli.Context) (*ipld.CountingBlockGetter, *lchtypes.Tip
 
 		// only a full mode RPC can act as a block source
 		if cctx.IsSet("rpc-fullnode") {
-			bg = &ipld.CountingBlockGetter{IpldBlockstore: &ipld.FilRpcBs{Rpc: lApi}}
+			if useFullCBG {
+				bg = &ipld.FullCBG{IpldBlockstore: &ipld.FilRpcBs{Rpc: lApi}}
+			} else {
+				bg = &ipld.LiteCBG{IpldBlockstore: &ipld.FilRpcBs{Rpc: lApi}}
+			}
 		}
 	}
 
 	// if no block sources available - fall back to public bitswap
 	if bg == nil {
-		bg, err = bitswap.InitBitswapGetter(ctx)
+		bg, err = bitswap.InitBitswapGetter(ctx, useFullCBG)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
This is something that both @parkan and @ArseniiPetrovich found useful in prod, so making it a proper PR.

Guys: **PLEASE TEST THIS EXTENSIVELY**, I might have missed a lock or two.

On top of the original f05 dump code, a number of improvements to bring the memory consumption down. Refer to latest 2 commits for details.

Things were tested with the usual runbook as per https://github.com/aschmahmann/filexp/commit/5d5a78235

Expected run times should be in the ballpark of:

```
$ go run ./ dump-statemarketdeals --car ../DATA/forest_snapshot_mainnet_2025-03-21_height_4808977.forest.car --tipset-cids bafy2bzaceaseg4tr42sx4wgxmvsgjn6ltg7weqggyfxhn7hiuad2ujbwyzm7s --single-document > /dev/null
2025-07-15T12:22:17.352+0200	INFO	filexp(70547)	ipld/car.go:23	duration to load snapshot: 601.784209ms
2025-07-15T12:22:17.352+0200	INFO	filexp(70547)	filexp/util.go:162	gathering results from StateRoot bafy2bzacecfsa7fnilawt7xhhqsbse6zf7rywarsorm2nywrm2tlofjujskjg referenced by tipset at height 4808977 (2025-03-21 16:48:30 +0000 UTC) [bafy2bzaceaseg4tr42sx4wgxmvsgjn6ltg7weqggyfxhn7hiuad2ujbwyzm7s]
2025-07-15T12:25:06.588+0200	INFO	filexp(70547)	ipld/blockgetter.go:59	blockgetterStats	{"blocksTotal": 8525423, "timeSinceFirstGet": "2m49.235s"}
```

and
```
$ GOMEMLIMIT=512MiB go run ./ dump-statemarketdeals --car ../DATA/forest_snapshot_mainnet_2025-03-21_height_4808977.forest.car --tipset-cids bafy2bzaceaseg4tr42sx4wgxmvsgjn6ltg7weqggyfxhn7hiuad2ujbwyzm7s --single-document > /dev/null
2025-07-15T12:25:10.464+0200	INFO	filexp(70604)	ipld/car.go:23	duration to load snapshot: 603.096458ms
2025-07-15T12:25:10.465+0200	INFO	filexp(70604)	filexp/util.go:162	gathering results from StateRoot bafy2bzacecfsa7fnilawt7xhhqsbse6zf7rywarsorm2nywrm2tlofjujskjg referenced by tipset at height 4808977 (2025-03-21 16:48:30 +0000 UTC) [bafy2bzaceaseg4tr42sx4wgxmvsgjn6ltg7weqggyfxhn7hiuad2ujbwyzm7s]
2025-07-15T12:40:50.894+0200	INFO	filexp(70604)	ipld/blockgetter.go:59	blockgetterStats	{"blocksTotal": 4782917, "timeSinceFirstGet": "15m40.47s"}

```

